### PR TITLE
implement fix for single store mode where store_ids isn't array

### DIFF
--- a/Controller/Adminhtml/ManageHooks/Save.php
+++ b/Controller/Adminhtml/ManageHooks/Save.php
@@ -79,7 +79,7 @@ class Save extends AbstractManageHooks
         }
 
         if (isset($data['store_ids']) && $data['store_ids']) {
-            $data['store_ids'] = implode(',', $data['store_ids']);
+            $data['store_ids'] = is_array($data['store_ids']) ? implode(',', $data['store_ids']) : $data['store_ids'];
         }
 
         $hook->addData($data);


### PR DESCRIPTION
This quick fix will allow sites in Single Store Mode to be able to save new Webhooks.

Currently these sites will receive an error due to `$data['store_ids']` not being an array.