### PR TITLE
Prevent Deprecated functionality exception

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -165,7 +165,7 @@ class Data extends CoreHelper
             ])
             ->setOrder('priority', 'ASC');
         $isSendMail     = $this->getConfigGeneral('alert_enabled');
-        $sendTo         = explode(',', $this->getConfigGeneral('send_to'));
+        $sendTo         = explode(',', $this->getConfigGeneral('send_to') ?? '');
         foreach ($hookCollection as $hook) {
             if ($hook->getHookType() === HookType::ORDER) {
                 $statusItem  = $item->getStatus();
@@ -418,7 +418,7 @@ class Data extends CoreHelper
             ->setOrder('priority', 'ASC');
 
         $isSendMail = $this->getConfigGeneral('alert_enabled');
-        $sendTo     = explode(',', $this->getConfigGeneral('send_to'));
+        $sendTo     = explode(',', $this->getConfigGeneral('send_to') ?? '');
 
         foreach ($hookCollection as $hook) {
             try {


### PR DESCRIPTION
In PHP 8 calling explode with "null" as argument will throw a Deprecated functionality exception